### PR TITLE
Add Initial Operator + Tests

### DIFF
--- a/presidio-anonymizer/presidio_anonymizer/operators/initial.py
+++ b/presidio-anonymizer/presidio_anonymizer/operators/initial.py
@@ -1,0 +1,39 @@
+from presidio_anonymizer.operators import Operator, OperatorType
+
+
+class Initial(Operator):
+    """Initial operator that converts names to initials."""
+
+    def operate(self, text: str, params=None):
+        if not text or not isinstance(text, str):
+            return text
+
+        # Remove extra whitespace and split words
+        words = text.strip().split()
+
+        initials = []
+        for word in words:
+            # Get first alphanumeric character in the word
+            first_char = None
+            for ch in word:
+                if ch.isalnum():
+                    first_char = ch.upper()
+                    break
+
+            # If no alphanumeric char found, skip
+            if not first_char:
+                continue
+
+            initials.append(f"{first_char}.")
+
+        # Join with space
+        return " ".join(initials)
+
+    def operator_name(self) -> str:
+        return "initial"
+
+    def operator_type(self) -> OperatorType:
+        return OperatorType.Anonymize
+
+    def validate(self, params: dict = None):
+        return

--- a/presidio-anonymizer/presidio_anonymizer/operators/initial.py
+++ b/presidio-anonymizer/presidio_anonymizer/operators/initial.py
@@ -2,31 +2,32 @@ from presidio_anonymizer.operators import Operator, OperatorType
 
 
 class Initial(Operator):
-    """Initial operator that converts names to initials."""
+    """Initial operator that converts names or multi-word identifiers into initials."""
 
     def operate(self, text: str, params=None):
         if not text or not isinstance(text, str):
             return text
 
-        # Remove extra whitespace and split words
         words = text.strip().split()
-
         initials = []
+
         for word in words:
-            # Get first alphanumeric character in the word
-            first_char = None
+            prefix = ""
+            first_alpha_num = None
+
+            # Detect prefix and first alphanumeric character
             for ch in word:
                 if ch.isalnum():
-                    first_char = ch.upper()
+                    first_alpha_num = ch.upper()
                     break
+                else:
+                    prefix += ch
 
-            # If no alphanumeric char found, skip
-            if not first_char:
-                continue
+            if not first_alpha_num:
+                continue  # Word has no alphanumeric chars
 
-            initials.append(f"{first_char}.")
+            initials.append(f"{prefix}{first_alpha_num}.")
 
-        # Join with space
         return " ".join(initials)
 
     def operator_name(self) -> str:


### PR DESCRIPTION
I added a new anonymizer operator called initial. This operator takes any detected PII (like names or multi-word text) and turns it into initials. For example, “John Smith” becomes “J. S.”.

I also added tests to make sure it works the way it should. The tests cover normal names, lowercase names, extra whitespace, and cases where the word starts with symbols (like “@abc”). Everything passes, including the old tests.

I registered the operator in the factory so it shows up in get_anonymizers() and can be used like the other operators.